### PR TITLE
Update cURL to use X-API key header

### DIFF
--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -35,14 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Http;
 
-use function curl_close;
 use function is_string;
-use function Safe\curl_exec;
-use function Safe\curl_getinfo;
+use function iterator_to_array;
+use function sprintf;
 use function Safe\curl_init;
-use function Safe\curl_setopt;
-use function Safe\json_encode;
-use function Safe\sprintf;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -54,6 +50,9 @@ class BadgeApiClient
 
     private const CREATED_RESPONSE_CODE = 201;
 
+    /**
+     * @var OutputInterface
+     */
     private $output;
 
     public function __construct(OutputInterface $output)
@@ -80,7 +79,7 @@ class BadgeApiClient
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, iterator_to_array($this->createHeaders($apiKey)));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
@@ -88,13 +87,29 @@ class BadgeApiClient
         $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
-        if ($responseCode !== self::CREATED_RESPONSE_CODE) {
+        if (self::CREATED_RESPONSE_CODE !== $responseCode) {
             $this->output->writeln(sprintf('Stryker dashboard returned an unexpected response code: %s', $responseCode));
         }
 
         if (is_string($response)) {
             $this->output->writeln('Dashboard response:', OutputInterface::VERBOSITY_VERBOSE);
             $this->output->writeln($response, OutputInterface::VERBOSITY_VERBOSE);
+        }
+    }
+
+    /**
+     * @param string $apiKey
+     * @return iterable
+     */
+    private function createHeaders(string $apiKey): iterable
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'X-Api-Key' => $apiKey,
+        ];
+
+        foreach ($headers as $key => $value) {
+            yield sprintf('%s: %s', $key, $value);
         }
     }
 }

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -37,7 +37,7 @@ namespace Infection\Http;
 
 use function is_string;
 use function iterator_to_array;
-use function sprintf;
+use function Safe\sprintf;
 use function Safe\curl_init;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -99,7 +99,7 @@ class BadgeApiClient
 
     /**
      * @param string $apiKey
-     * @return iterable
+     * @return iterable<string>
      */
     private function createHeaders(string $apiKey): iterable
     {


### PR DESCRIPTION
Stryker fails if there is no X-API key header (see https://github.com/stryker-mutator/stryker-handbook/blob/master/dashboard.md for expected cURL schema.)

This PR:

- [ ] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

<!--
Remove if not relevant
-->

Fixes https://github.com/infection/infection/issues/XXX

<!--
- Replace this comment by a detailed description of what your PR is solving.
- Use labels for different kinds of PR like `performance`, `feature`, etc.
- Use Milestone to show when this code is going to be released.

Deprecations? don't forget to update UPGRADE-*.md files
-->